### PR TITLE
話者が増えていた際に音声パラメタが存在しない問題を修正

### DIFF
--- a/FakeChan/MainWindow.xaml.cs
+++ b/FakeChan/MainWindow.xaml.cs
@@ -221,6 +221,31 @@ namespace FakeChan
                 return;
             }
 
+            try
+            {
+                // 以前より話者が増えていた場合、その話者発声パラメータを初期化
+
+                foreach (ListenInterface InterfaceIdx in Enum.GetValues(typeof(ListenInterface)))
+                {
+                    foreach (BouyomiVoice BouIdx in Enum.GetValues(typeof(BouyomiVoice)))
+                    {
+                        foreach (int cid in Config.AvatorNames.Keys)
+                        {
+                            if (!UserData.VoiceParams[(int)InterfaceIdx][(int)BouIdx].ContainsKey(cid))
+                            {
+                                UserData.VoiceParams[(int)InterfaceIdx][(int)BouIdx][cid] = Config.AvatorParams(cid);
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception e0)
+            {
+                MessageBox.Show(e0.Message, "設定値読み込みの問題5");
+                Application.Current.Shutdown();
+                return;
+            }
+
             // サイレントメッセージ最大待ち時間
             if (UserData.QuietMessages.Count != 0)
             {

--- a/FakeChan/MainWindow.xaml.cs
+++ b/FakeChan/MainWindow.xaml.cs
@@ -223,7 +223,7 @@ namespace FakeChan
 
             try
             {
-                // 以前より話者が増えていた場合、その話者音声パラメタを初期化
+                // 以前より話者が増えていた場合、その話者の音声パラメタを初期化
 
                 foreach (ListenInterface InterfaceIdx in Enum.GetValues(typeof(ListenInterface)))
                 {

--- a/FakeChan/MainWindow.xaml.cs
+++ b/FakeChan/MainWindow.xaml.cs
@@ -223,7 +223,7 @@ namespace FakeChan
 
             try
             {
-                // 以前より話者が増えていた場合、その話者発声パラメータを初期化
+                // 以前より話者が増えていた場合、その話者音声パラメタを初期化
 
                 foreach (ListenInterface InterfaceIdx in Enum.GetValues(typeof(ListenInterface)))
                 {


### PR DESCRIPTION
# 症状
1. 偽装ちゃんの設定をリセットする（設定ファイルを削除するなどして）
2. AssistantSeikaと偽装ちゃんを一度起動した後、AssistantSeikaで使用する製品を追加するなどして適当な話者を増やす
3. 偽装ちゃんを起動しなおす
4. `話者設定` で追加された話者を適当な話者マップに割り当てる
5. 割り当てた話者を `音声設定` で選択すると偽装ちゃんがクラッシュする

# 原因
- `UserData.VoiceParams` は初回起動時にしか初期化されない
https://github.com/k896951/FakeChan/blob/bf74bc176f7a6ac3be658d239227da3ef4a0b820/FakeChan/MainWindow.xaml.cs#L165

# 対応
- 起動時に `UserData.VoiceParams` に音声パラメタの漏れが無いかを確認し、なければ追加する処理を追加した